### PR TITLE
Organize gems into appropriate groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'rspec'
-gem 'guard-rake'
-gem 'rake'
-gem 'nokogiri'
 gem 'git'
+gem 'nokogiri'
+gem 'rake'
 
 group :test, :development do
+  gem 'guard-rake'
   gem 'pry-byebug'
+  gem 'rspec'
 end


### PR DESCRIPTION
If we're going to have test and dev groups, we should use them.
